### PR TITLE
Improve script ux

### DIFF
--- a/deployseason01.sh
+++ b/deployseason01.sh
@@ -1,7 +1,19 @@
 #!/bin/bash
 
+# Function for continue/exit prompt
+continue_or_exit() {
+    local message="$1"
+    echo "$message"
+    echo -e "\033[1;34mPress any key to continue, q to quit.\033[0m"
+    read -n 1 key
+    if [[ $key == "q" ]]; then
+        exit 1
+    fi
+}
+
 echo "Enter the network name (e.g. opsepolia, optimism, sepolia, basesepolia, base):"
 read NETWORK
+
 
 # Validate network name against supported chains
 case $NETWORK in
@@ -19,40 +31,50 @@ case $NETWORK in
     ;;
 esac
 
+CONTRACTS_DIR="protocolcontracts/${NETWORK}"
 
+# Delete existing contracts directory if it exists
+if [ -d "$CONTRACTS_DIR" ]; then
+    rm -rf "$CONTRACTS_DIR"
+fi
+
+exit 0
+
+
+echo -e "While this script runs, it will deploy the following contracts:"
+echo -e "ERC20"
+echo -e "Builder NFT"
+echo -e "Vesting"
+echo -e "EAS Resolver"
+echo -e "Protocol"
+
+continue_or_exit ""
 
 npm run compile
 npm run scout:deploy:erc20 $NETWORK || exit 1
-echo "ERC20 deployment completed. Press enter to continue, any other key to exit."
-read -n 1 key
-if [[ $key != "" ]]; then
-    exit 1
-fi
+continue_or_exit "ERC20 deployment completed."
 
 npm run scout:deploy:buildernft $NETWORK || exit 1
-echo "Builder NFT deployment completed. Press enter to continue, any other key to exit."
-read -n 1 key
-if [[ $key != "" ]]; then
-    exit 1
-fi
+continue_or_exit "Builder NFT deployment completed."
 
 npm run scout:deploy:vesting $NETWORK || exit 1
-echo "Vesting deployment completed. Press enter to continue, any other key to exit."
-read -n 1 key
-if [[ $key != "" ]]; then
-    exit 1
-fi
+continue_or_exit "Vesting deployment completed."
 
 npm run scout:deploy:easresolver $NETWORK || exit 1
-echo "EAS Resolver deployment completed. Press enter to continue, any other key to exit."
-read -n 1 key
-if [[ $key != "" ]]; then
-    exit 1
-fi
+continue_or_exit "EAS Resolver deployment completed."
 
 npm run scout:deploy:protocol $NETWORK || exit 1
 echo "Protocol deployment completed."
 
-echo -e "Copy over the contract addresses to scripts/deploy/prepareScoutGameLaunchSafeTransaction.ts"
+echo ""
+echo "----------------------------------------"
+echo ""
+
+echo -e "All contract addresses have been saved to the protocolcontracts/${NETWORK} directory."
+
+echo ""
+echo "----------------------------------------"
+echo ""
+
 echo -e "Once done, run this command to deploy the safe transaction:"
 echo -e "\033[1;34mnpm run scout:launch:season01\033[0m"

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -29,6 +29,7 @@ import './scripts/deploy/protocol/03_deployVesting';
 import './scripts/deploy/protocol/04_deployEASResolver';
 import './scripts/deploy/protocol/05_deployScoutProtocol';
 import './scripts/deploy/protocol/prepareScoutGameLaunchSafeTransaction';
+import './scripts/deploy/protocol/verifyContracts';
 
 import './scripts/verifyViaTenderly';
 // Interactions ------------------------------

--- a/lib/outputContract.ts
+++ b/lib/outputContract.ts
@@ -1,7 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-type DeployedContractInfo = {
+export type DeployedContractInfo = {
   name: string;
   address: string;
   network: string;

--- a/lib/outputContract.ts
+++ b/lib/outputContract.ts
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function outputContractAddress({ name, address, network }: { name: string; address: string; network: string }) {
+  // Check if protocolcontracts directory exists, create if not
+  const contractsDir = path.resolve('protocolcontracts');
+  if (!fs.existsSync(contractsDir)) {
+    fs.mkdirSync(contractsDir);
+  }
+
+  const contractWithNetworkDir = path.join(contractsDir, network);
+
+  if (!fs.existsSync(contractWithNetworkDir)) {
+    fs.mkdirSync(contractWithNetworkDir);
+  }
+
+  const contractFile = path.join(contractWithNetworkDir, `${name}.json`);
+  fs.writeFileSync(contractFile, JSON.stringify({ name, address, network }, null, 2));
+}

--- a/lib/outputContract.ts
+++ b/lib/outputContract.ts
@@ -1,7 +1,23 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-export function outputContractAddress({ name, address, network }: { name: string; address: string; network: string }) {
+type DeployedContractInfo = {
+  name: string;
+  address: string;
+  network: string;
+  contractArtifactSource: string;
+  metadata?: any;
+  deployArgs?: any[];
+};
+
+export function outputContractAddress({
+  name,
+  address,
+  network,
+  contractArtifactSource,
+  metadata = {},
+  deployArgs = []
+}: DeployedContractInfo) {
   // Check if protocolcontracts directory exists, create if not
   const contractsDir = path.resolve('protocolcontracts');
   if (!fs.existsSync(contractsDir)) {
@@ -15,5 +31,8 @@ export function outputContractAddress({ name, address, network }: { name: string
   }
 
   const contractFile = path.join(contractWithNetworkDir, `${name}.json`);
-  fs.writeFileSync(contractFile, JSON.stringify({ name, address, network }, null, 2));
+  fs.writeFileSync(
+    contractFile,
+    JSON.stringify({ name, address, network, contractArtifactSource, metadata, deployArgs }, null, 2)
+  );
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "deploybuilders": "npm run compile && npx hardhat deployBuilderNFTSeasonOne --network",
     "deploybuilders:pres02": "npm run compile && npx hardhat deployBuilderNFTPreSeason02 --network",
     "deploybuilders:starterpack": "npm run compile && npx hardhat deployScoutGameStarterPackNFT --network",
-    "scout:deploy:season01": "npm run compile && chmod +x ./deployseason01.sh && ./deployseason01.sh",
+    "scout:deploy:season01": "npm run compile && chmod +x ./scripts/shell/deployseason01.sh && ./scripts/shell/deployseason01.sh",
     "scout:launch:season01": "npx hardhat prepareScoutGameLaunchSafeTransaction --network",
     "deploy:create2deployer": "npx hardhat deployFoundryCreate2Deployer --network",
     "proxy:update": "npx hardhat updateProxyImplementation --network",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "deploybuilders:pres02": "npm run compile && npx hardhat deployBuilderNFTPreSeason02 --network",
     "deploybuilders:starterpack": "npm run compile && npx hardhat deployScoutGameStarterPackNFT --network",
     "scout:deploy:season01": "npm run compile && chmod +x ./scripts/shell/deployseason01.sh && ./scripts/shell/deployseason01.sh",
+    "scout:verify:season01": "npm run compile && npx hardhat verifyDeployedContracts --network",
     "scout:launch:season01": "npx hardhat prepareScoutGameLaunchSafeTransaction --network",
     "deploy:create2deployer": "npx hardhat deployFoundryCreate2Deployer --network",
     "proxy:update": "npx hardhat updateProxyImplementation --network",

--- a/protocolcontracts/basesepolia/LockupWeeklyStreamCreator.json
+++ b/protocolcontracts/basesepolia/LockupWeeklyStreamCreator.json
@@ -1,8 +1,8 @@
 {
-  "name": "SablierLockupWeeklyStreamCreator",
+  "name": "LockupWeeklyStreamCreator",
   "address": "0x9caa8adbb7d0ecddfac137d37e3bde3aacd39384",
   "network": "basesepolia",
-  "contractArtifactSource": "contracts/protocol/contracts/Vesting/SablierLockupWeeklyStreamCreator.sol:SablierLockupWeeklyStreamCreator",
+  "contractArtifactSource": "contracts/protocol/contracts/Vesting/LockupWeeklyStreamCreator.sol:LockupWeeklyStreamCreator",
   "metadata": {},
   "deployArgs": [
     "0xae2a92bde75a5e1484fc279633bffdb58819c1f3",

--- a/protocolcontracts/basesepolia/ProtocolEASResolver.json
+++ b/protocolcontracts/basesepolia/ProtocolEASResolver.json
@@ -1,0 +1,11 @@
+{
+  "name": "ProtocolEASResolver",
+  "address": "0xd2a91c9c20bf34c44ea138a4a9014178f97d4130",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/EAS/ProtocolEASResolver.sol:ProtocolEASResolver",
+  "metadata": {},
+  "deployArgs": [
+    "0x4200000000000000000000000000000000000021",
+    "0x7388202AEA587c5748F3d1E0ad63ff3A2C6b3Ed4"
+  ]
+}

--- a/protocolcontracts/basesepolia/SablierLockupWeeklyStreamCreator.json
+++ b/protocolcontracts/basesepolia/SablierLockupWeeklyStreamCreator.json
@@ -1,0 +1,11 @@
+{
+  "name": "SablierLockupWeeklyStreamCreator",
+  "address": "0x9caa8adbb7d0ecddfac137d37e3bde3aacd39384",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/Vesting/SablierLockupWeeklyStreamCreator.sol:SablierLockupWeeklyStreamCreator",
+  "metadata": {},
+  "deployArgs": [
+    "0xae2a92bde75a5e1484fc279633bffdb58819c1f3",
+    "0xb8c724df3eC8f2Bf8fA808dF2cB5dbab22f3E68c"
+  ]
+}

--- a/protocolcontracts/basesepolia/ScoutProtocolBuilderNFTImplementation.json
+++ b/protocolcontracts/basesepolia/ScoutProtocolBuilderNFTImplementation.json
@@ -1,0 +1,8 @@
+{
+  "name": "ScoutProtocolBuilderNFTImplementation",
+  "address": "0xb8031be723081ed7b9fc5ac47475cdf9f70cbbd4",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ERC1155/ScoutProtocolBuilderNFTImplementation.sol:ScoutProtocolBuilderNFTImplementation",
+  "metadata": {},
+  "deployArgs": []
+}

--- a/protocolcontracts/basesepolia/ScoutProtocolERC1155BuilderNFTProxy.json
+++ b/protocolcontracts/basesepolia/ScoutProtocolERC1155BuilderNFTProxy.json
@@ -1,0 +1,14 @@
+{
+  "name": "ScoutProtocolERC1155BuilderNFTProxy",
+  "address": "0xa7ab91644fc037b79c1bc3c6c642a46e65b53b0d",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ERC1155/ScoutProtocolBuilderNFTProxy.sol:ScoutProtocolBuilderNFTProxy",
+  "metadata": {},
+  "deployArgs": [
+    "0xb8031be723081ed7b9fc5ac47475cdf9f70cbbd4",
+    "0xae2a92bde75a5e1484fc279633bffdb58819c1f3",
+    "0x93326D53d1E8EBf0af1Ff1B233c46C67c96e4d8D",
+    "\"ScoutGame (Season 01)\"",
+    "\"SCOUTGAME-S01\""
+  ]
+}

--- a/protocolcontracts/basesepolia/ScoutProtocolImplementation.json
+++ b/protocolcontracts/basesepolia/ScoutProtocolImplementation.json
@@ -1,0 +1,8 @@
+{
+  "name": "ScoutProtocolImplementation",
+  "address": "0xc2ea862c983c3ea57221e7b538f9cd7712cddd54",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ScoutProtocol/ScoutProtocolImplementation.sol:ScoutProtocolImplementation",
+  "metadata": {},
+  "deployArgs": []
+}

--- a/protocolcontracts/basesepolia/ScoutProtocolProxy.json
+++ b/protocolcontracts/basesepolia/ScoutProtocolProxy.json
@@ -1,0 +1,11 @@
+{
+  "name": "ScoutProtocolProxy",
+  "address": "0xf697c46412683c0d83d5482dc26c8e4cd63972b6",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ScoutProtocol/ScoutProtocolProxy.sol:ScoutProtocolProxy",
+  "metadata": {},
+  "deployArgs": [
+    "0xc2ea862c983c3ea57221e7b538f9cd7712cddd54",
+    "0xae2a92bde75a5e1484fc279633bffdb58819c1f3"
+  ]
+}

--- a/protocolcontracts/basesepolia/ScoutTokenERC20Implementation.json
+++ b/protocolcontracts/basesepolia/ScoutTokenERC20Implementation.json
@@ -1,0 +1,10 @@
+{
+  "name": "ScoutTokenERC20Implementation",
+  "address": "0xf92d9aacb7f033dd01119775a11db69516b670ab",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ERC20/ScoutTokenERC20Implementation.sol:ScoutTokenERC20Implementation",
+  "metadata": {
+    "salt": "0x00055555555555555555535155b88848f5599cdaaae328fbdd36ff0682012292"
+  },
+  "deployArgs": []
+}

--- a/protocolcontracts/basesepolia/ScoutTokenERC20Proxy.json
+++ b/protocolcontracts/basesepolia/ScoutTokenERC20Proxy.json
@@ -1,0 +1,14 @@
+{
+  "name": "ScoutTokenERC20Proxy",
+  "address": "0xae2a92bde75a5e1484fc279633bffdb58819c1f3",
+  "network": "basesepolia",
+  "contractArtifactSource": "contracts/protocol/contracts/ERC20/ScoutTokenERC20Proxy.sol:ScoutTokenERC20Proxy",
+  "metadata": {
+    "deployer": "0x7388202AEA587c5748F3d1E0ad63ff3A2C6b3Ed4",
+    "salt": "0x00055555555555555555535155b88848f5599cdaaae328fbdd36ff0682012292"
+  },
+  "deployArgs": [
+    "0xf92d9aacb7f033dd01119775a11db69516b670ab",
+    "0x93cc4a36D510B9D65325A795EE41201f9232fa4D"
+  ]
+}

--- a/scripts/deploy/protocol/01_deployDeterministicScoutgameTokenERC20.ts
+++ b/scripts/deploy/protocol/01_deployDeterministicScoutgameTokenERC20.ts
@@ -20,6 +20,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { getConnectorFromHardhatRuntimeEnvironment, getConnectorKey } from '../../../lib/connectors';
 import { getScoutProtocolSafeAddress } from '../../../lib/constants';
+import { outputContractAddress } from '../../../lib/outputContract';
 
 /**
  * Computes the deterministic address for a contract using the CREATE2 formula.
@@ -102,7 +103,7 @@ task('deployDeterministicScoutGameERC20', 'Deploys or updates the Scout Game ERC
     log.info('Using account:', account.address, 'on chain:', connector.chain.name);
 
     // Encode the function call with parameters
-    const salt = '0x0000055555555555001283d1d5b88848fb799cdaaae328fbdd36ff0682012292';
+    const salt = '0x0000055555555555501283d1d5b88848fb799cdaaae328fbdd36ff0682012292';
 
     // Base will hold the supply, and other L2s will be compatible
 
@@ -169,6 +170,12 @@ task('deployDeterministicScoutGameERC20', 'Deploys or updates the Scout Game ERC
     }
 
     log.info('Deployed Scout Token ERC20 proxy address: ', expectedProxyAddress);
+
+    outputContractAddress({
+      name: 'ScoutTokenERC20Proxy',
+      address: expectedProxyAddress,
+      network: getConnectorKey(connector.chain.id)
+    });
   }
 );
 

--- a/scripts/deploy/protocol/02_deployScoutProtocolBuilderNft.ts
+++ b/scripts/deploy/protocol/02_deployScoutProtocolBuilderNft.ts
@@ -9,6 +9,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { getConnectorFromHardhatRuntimeEnvironment, getConnectorKey, proceedsReceiver } from '../../../lib/connectors';
 import { getScoutProtocolSafeAddress } from '../../../lib/constants';
+import { outputContractAddress } from '../../../lib/outputContract';
 
 dotenv.config();
 
@@ -184,6 +185,12 @@ task('deployScoutProtocolBuilderNFT', 'Deploys or updates the Scout Protocol Bui
       const proxyAddress = newProxyContract.address;
 
       console.log('ERC1155 Proxy contract deployed at:', proxyAddress);
+
+      outputContractAddress({
+        name: 'ScoutProtocolERC1155BuilderNFTProxy',
+        address: proxyAddress,
+        network: getConnectorKey(connector.chain.id)
+      });
 
       try {
         execSync(

--- a/scripts/deploy/protocol/02_deployScoutProtocolBuilderNft.ts
+++ b/scripts/deploy/protocol/02_deployScoutProtocolBuilderNft.ts
@@ -54,6 +54,15 @@ task('deployScoutProtocolBuilderNFT', 'Deploys or updates the Scout Protocol Bui
       console.warn('Error verifying contract', err);
     }
 
+    outputContractAddress({
+      name: 'ScoutProtocolBuilderNFTImplementation',
+      address: implementationAddress,
+      network: getConnectorKey(connector.chain.id),
+      contractArtifactSource:
+        'contracts/protocol/contracts/ERC1155/ScoutProtocolBuilderNFTImplementation.sol:ScoutProtocolBuilderNFTImplementation',
+      deployArgs: []
+    });
+
     let deployNew = true;
 
     // Prompt the user to update the implementation if the proxy already exists
@@ -189,7 +198,10 @@ task('deployScoutProtocolBuilderNFT', 'Deploys or updates the Scout Protocol Bui
       outputContractAddress({
         name: 'ScoutProtocolERC1155BuilderNFTProxy',
         address: proxyAddress,
-        network: getConnectorKey(connector.chain.id)
+        contractArtifactSource:
+          'contracts/protocol/contracts/ERC1155/ScoutProtocolBuilderNFTProxy.sol:ScoutProtocolBuilderNFTProxy',
+        network: getConnectorKey(connector.chain.id),
+        deployArgs: deployArgs.slice()
       });
 
       try {

--- a/scripts/deploy/protocol/03_deployVesting.ts
+++ b/scripts/deploy/protocol/03_deployVesting.ts
@@ -56,7 +56,7 @@ task('deployVesting', 'Deploys or updates the Sablier Vesting contract').setActi
     name: 'SablierLockupWeeklyStreamCreator',
     address: sablierLockupAddress,
     contractArtifactSource:
-      'contracts/protocol/contracts/Vesting/SablierLockupWeeklyStreamCreator.sol:SablierLockupWeeklyStreamCreator',
+      'contracts/protocol/contracts/Vesting/LockupWeeklyStreamCreator.sol:LockupWeeklyStreamCreator',
     network: getConnectorKey(connector.chain.id),
     deployArgs: deployArgs.slice()
   });

--- a/scripts/deploy/protocol/03_deployVesting.ts
+++ b/scripts/deploy/protocol/03_deployVesting.ts
@@ -55,7 +55,10 @@ task('deployVesting', 'Deploys or updates the Sablier Vesting contract').setActi
   outputContractAddress({
     name: 'SablierLockupWeeklyStreamCreator',
     address: sablierLockupAddress,
-    network: getConnectorKey(connector.chain.id)
+    contractArtifactSource:
+      'contracts/protocol/contracts/Vesting/SablierLockupWeeklyStreamCreator.sol:SablierLockupWeeklyStreamCreator',
+    network: getConnectorKey(connector.chain.id),
+    deployArgs: deployArgs.slice()
   });
 
   // Verify contract in the explorer

--- a/scripts/deploy/protocol/03_deployVesting.ts
+++ b/scripts/deploy/protocol/03_deployVesting.ts
@@ -8,6 +8,7 @@ import { createWalletClient, http, isAddress } from 'viem';
 import { privateKeyToAccount } from 'viem/accounts';
 
 import { getConnectorFromHardhatRuntimeEnvironment, getConnectorKey } from '../../../lib/connectors';
+import { outputContractAddress } from '../../../lib/outputContract';
 
 dotenv.config();
 
@@ -50,6 +51,12 @@ task('deployVesting', 'Deploys or updates the Sablier Vesting contract').setActi
   if (!sablierLockupAddress) {
     throw new Error('Failed to deploy erc20 contract');
   }
+
+  outputContractAddress({
+    name: 'SablierLockupWeeklyStreamCreator',
+    address: sablierLockupAddress,
+    network: getConnectorKey(connector.chain.id)
+  });
 
   // Verify contract in the explorer
 

--- a/scripts/deploy/protocol/04_deployEASResolver.ts
+++ b/scripts/deploy/protocol/04_deployEASResolver.ts
@@ -65,7 +65,9 @@ task('deployEASResolver', 'Deploys or updates the EAS Resolver and scoutgame att
     outputContractAddress({
       name: 'ProtocolEASResolver',
       address: resolverAddress,
-      network: getConnectorKey(connector.chain.id)
+      network: getConnectorKey(connector.chain.id),
+      contractArtifactSource: 'contracts/protocol/contracts/EAS/ProtocolEASResolver.sol:ProtocolEASResolver',
+      deployArgs: deployArgs.slice()
     });
 
     console.log(`Transferring Admin role to Safe Address: ${adminAddress}`);

--- a/scripts/deploy/protocol/04_deployEASResolver.ts
+++ b/scripts/deploy/protocol/04_deployEASResolver.ts
@@ -8,6 +8,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { getConnectorFromHardhatRuntimeEnvironment, getConnectorKey } from '../../../lib/connectors';
 import { getScoutProtocolSafeAddress } from '../../../lib/constants';
+import { outputContractAddress } from '../../../lib/outputContract';
 
 dotenv.config();
 
@@ -60,6 +61,12 @@ task('deployEASResolver', 'Deploys or updates the EAS Resolver and scoutgame att
     }
 
     console.log('EAS Resolver contract deployed at:', deployedResolver.address);
+
+    outputContractAddress({
+      name: 'ProtocolEASResolver',
+      address: resolverAddress,
+      network: getConnectorKey(connector.chain.id)
+    });
 
     console.log(`Transferring Admin role to Safe Address: ${adminAddress}`);
 

--- a/scripts/deploy/protocol/05_deployScoutProtocol.ts
+++ b/scripts/deploy/protocol/05_deployScoutProtocol.ts
@@ -46,6 +46,15 @@ task('deployScoutProtocol', 'Deploys or updates the ScoutProtocol contracts').se
 
   const implementationAddress = deployedImplementation.address;
 
+  outputContractAddress({
+    name: 'ScoutProtocolImplementation',
+    contractArtifactSource:
+      'contracts/protocol/contracts/ScoutProtocol/ScoutProtocolImplementation.sol:ScoutProtocolImplementation',
+    address: implementationAddress,
+    network: getConnectorKey(connector.chain.id),
+    deployArgs: []
+  });
+
   if (!implementationAddress) {
     throw new Error('Failed to deploy implementation contract');
   }
@@ -167,7 +176,9 @@ task('deployScoutProtocol', 'Deploys or updates the ScoutProtocol contracts').se
     outputContractAddress({
       name: 'ScoutProtocolProxy',
       address: proxyAddress,
-      network: getConnectorKey(connector.chain.id)
+      network: getConnectorKey(connector.chain.id),
+      contractArtifactSource: 'contracts/protocol/contracts/ScoutProtocol/ScoutProtocolProxy.sol:ScoutProtocolProxy',
+      deployArgs: deployArgs.slice()
     });
 
     console.log(`Transferring Admin role to Safe Address: ${adminAddress}`);

--- a/scripts/deploy/protocol/05_deployScoutProtocol.ts
+++ b/scripts/deploy/protocol/05_deployScoutProtocol.ts
@@ -9,6 +9,7 @@ import { privateKeyToAccount } from 'viem/accounts';
 
 import { getConnectorFromHardhatRuntimeEnvironment, getConnectorKey } from '../../../lib/connectors';
 import { getScoutProtocolSafeAddress } from '../../../lib/constants';
+import { outputContractAddress } from '../../../lib/outputContract';
 
 dotenv.config();
 
@@ -162,6 +163,12 @@ task('deployScoutProtocol', 'Deploys or updates the ScoutProtocol contracts').se
     } catch (err) {
       console.warn('Error verifying contract', err);
     }
+
+    outputContractAddress({
+      name: 'ScoutProtocolProxy',
+      address: proxyAddress,
+      network: getConnectorKey(connector.chain.id)
+    });
 
     console.log(`Transferring Admin role to Safe Address: ${adminAddress}`);
 

--- a/scripts/deploy/protocol/prepareScoutGameLaunchSafeTransaction.ts
+++ b/scripts/deploy/protocol/prepareScoutGameLaunchSafeTransaction.ts
@@ -235,6 +235,43 @@ task('prepareScoutGameLaunchSafeTransaction', 'Deploys or updates the Scout Game
 
     log.info('Collected all required addresses and parameters');
 
+    // Get contract instances and verify implementations
+    const erc1155Contract = await hre.viem.getContractAt(
+      'ScoutProtocolBuilderNFTProxy',
+      scoutBuilderNFTERC1155ProxyAddress
+    );
+    const erc20Contract = await hre.viem.getContractAt('ScoutTokenERC20Proxy', scoutTokenERC20ProxyAddress);
+    const protocolContract = await hre.viem.getContractAt('ScoutProtocolProxy', scoutProtocolAddress);
+
+    // Verify implementations resolves
+    const erc1155Implementation = await erc1155Contract.read.implementation().catch(() => {
+      console.error('Error verifying ERC1155 implementation');
+      return null;
+    });
+    if (!erc1155Implementation || !isAddress(erc1155Implementation)) {
+      throw new Error('Invalid ERC1155 proxy address. Make sure you passed the proxy, not the implementation address.');
+    }
+
+    const erc20Implementation = await erc20Contract.read.implementation().catch(() => {
+      console.error('Error verifying ERC20 implementation');
+      return null;
+    });
+    if (!erc20Implementation || !isAddress(erc20Implementation)) {
+      throw new Error('Invalid ERC20 proxy address. Make sure you passed the proxy, not the implementation address.');
+    }
+
+    const protocolImplementation = await protocolContract.read.implementation().catch(() => {
+      console.error('Error verifying Protocol implementation');
+      return null;
+    });
+    if (!protocolImplementation || !isAddress(protocolImplementation)) {
+      throw new Error(
+        'Invalid Protocol proxy address. Make sure you passed the proxy, not the implementation address.'
+      );
+    }
+
+    log.info('Verified all contract implementations resolve correctly');
+
     // Safe Address which admins all contracts
     const safeAddress = getScoutProtocolSafeAddress();
 

--- a/scripts/deploy/protocol/verifyContracts.ts
+++ b/scripts/deploy/protocol/verifyContracts.ts
@@ -1,0 +1,43 @@
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import dotenv from 'dotenv';
+import { task } from 'hardhat/config';
+
+import type { DeployedContractInfo } from '../../../lib/outputContract';
+
+dotenv.config();
+
+task('verifyDeployedContracts', 'Deploys or updates the Scout Game ERC20 contract').setAction(async (taskArgs, hre) => {
+  const contracts = fs.readdirSync(path.resolve('protocolcontracts', hre.network.name));
+
+  for (const contract of contracts) {
+    const contractData = JSON.parse(
+      fs.readFileSync(path.resolve('protocolcontracts', hre.network.name, contract), 'utf8')
+    ) as DeployedContractInfo;
+
+    console.log(`\r\n-------- START VERIFYING CONTRACT ${contractData.name} --------\r\n`);
+
+    const command = `npx hardhat verify --force --network ${hre.network.name} --contract ${contractData.contractArtifactSource} ${contractData.address} ${contractData.deployArgs?.join(' ')}`;
+
+    try {
+      console.log(`Verifying contract ${contractData.name} at address ${contractData.address}`);
+      console.log(command);
+      execSync(command);
+    } catch (err: any) {
+      const stdout = err.stdout ? Buffer.from(err.stdout).toString() : '';
+      const stderr = err.stderr ? Buffer.from(err.stderr).toString() : '';
+
+      if (stdout.match(/already.*verified/) || stderr.match(/already.*verified/)) {
+        console.log(`Contract ${contractData.name} at address ${contractData.address} already verified`);
+      } else {
+        console.warn('Error verifying contract', err);
+      }
+    }
+
+    console.log(`\r\n-------- END VERIFYING CONTRACT ${contractData.name} --------\r\n`);
+  }
+});
+
+module.exports = {};

--- a/scripts/shell/deployseason01.sh
+++ b/scripts/shell/deployseason01.sh
@@ -31,14 +31,15 @@ case $NETWORK in
     ;;
 esac
 
-CONTRACTS_DIR="protocolcontracts/${NETWORK}"
 
-# Delete existing contracts directory if it exists
+CONTRACTS_DIR="protocolcontracts/$NETWORK"
+
+# Check if contracts directory exists and remove it
 if [ -d "$CONTRACTS_DIR" ]; then
+    echo "Removing existing contracts directory: $CONTRACTS_DIR"
     rm -rf "$CONTRACTS_DIR"
 fi
 
-exit 0
 
 
 echo -e "While this script runs, it will deploy the following contracts:"
@@ -70,7 +71,7 @@ echo ""
 echo "----------------------------------------"
 echo ""
 
-echo -e "All contract addresses have been saved to the protocolcontracts/${NETWORK} directory."
+echo -e "All contract addresses have been saved to the $CONTRACTS_DIR directory."
 
 echo ""
 echo "----------------------------------------"


### PR DESCRIPTION
This improves the deployments further

All contracts are outputted to the **protocolcontracts/<network-name>** folder.

This removes the need to parse the values from the terminal.

Added a verify script so verification of all contracts can be retriggered.

Added protection against putting in implementations instead of proxies